### PR TITLE
Experiment: property-based tests for verifiable logs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 
 dependencies {
     testCompile junit
+    testCompile 'org.quicktheories:quicktheories:0.12'
 }
 
 jar.baseName = "verifiable-log"

--- a/src/test/java/uk/gov/verifiablelog/merkletree/MerkleTreeTests.java
+++ b/src/test/java/uk/gov/verifiablelog/merkletree/MerkleTreeTests.java
@@ -2,6 +2,7 @@ package uk.gov.verifiablelog.merkletree;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.quicktheories.quicktheories.core.Source;
 
 import javax.xml.bind.DatatypeConverter;
 import java.security.MessageDigest;
@@ -9,10 +10,14 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.quicktheories.quicktheories.QuickTheory.qt;
+import static org.quicktheories.quicktheories.generators.SourceDSL.*;
 
 public class MerkleTreeTests {
 
@@ -129,6 +134,44 @@ public class MerkleTreeTests {
         assertThat(bytesToString(consistencySet4), is(Arrays.asList(
                 "5f083f0a1a33ca076a95279832580db3e0ef4584bdff1f54c8a360f50de3031e",
                 "bc1a0643b12e4d2d7c77918f44e0f4f79a838b6cf9ec5b5c283e1f4d88599e6b")));
+    }
+
+    @Test
+    public void property_merkleTreeHashIs32Bytes() throws Exception {
+        Source<String> source = strings().allPossible().ofLengthBetween(0,50);
+        qt().forAll(lists().allListsOf(source).ofSizeBetween(0,50))
+                .check(entries -> {
+                    MerkleTree merkleTree = sha256MerkleTree(i -> entries.get(i).getBytes(), entries::size);
+                    return merkleTree.currentRoot().length == 32;
+                });
+    }
+
+    private int treeHeightForSize(int size) {
+        int height = 0;
+        size--;
+        while (size != 0) {
+            size >>= 1;
+            height++;
+        }
+        return height+1;
+    }
+
+    @Test
+    public void property_auditPathLengthForIndex0IsTreeHeightMinusOne() throws Exception {
+        qt().forAll(lists().allListsOf(strings().numeric()).ofSizeBetween(2,1000))
+                .check(entries -> {
+                    MerkleTree merkleTree = sha256MerkleTree(i -> entries.get(i).getBytes(), entries::size);
+                    List<byte[]> auditPath = merkleTree.pathToRootAtSnapshot(0, entries.size());
+                    return auditPath.size() == treeHeightForSize(entries.size()) - 1;
+                });
+    }
+
+    private MerkleTree sha256MerkleTree(Function<Integer, byte[]> leafAccessFunction, Supplier<Integer> leafSizeFunction) {
+        try {
+            return new MerkleTree(MessageDigest.getInstance("SHA-256"), leafAccessFunction, leafSizeFunction);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("can't happen"); // can't happen, SHA-256 is guaranteed
+        }
     }
 
     private List<String> bytesToString(List<byte[]> listOfByteArrays) {


### PR DESCRIPTION
This introduces QuickTheories as a tool to perform property-based testing
on our MerkleTree class.  Currently it checks two properties:
- a root hash is exactly 32 bytes wide (not that interesting)
- an audit path to the first node in a tree has a length equal to the tree height minus one.

One can imagine other properties such as:
- a valid audit path is always verifiable
- a valid consistency proof is always verifiable
