### PR TITLE
Property test to verify audit path proof

### DIFF
--- a/src/main/java/uk/gov/verifiablelog/merkletree/MerkleTree.java
+++ b/src/main/java/uk/gov/verifiablelog/merkletree/MerkleTree.java
@@ -42,7 +42,7 @@ public class MerkleTree {
             consistencySet.add(subtreeHash(start, end, leafDAOFunction.apply(start, end)));
             return consistencySet;
         }
-        int k = k(size);
+        int k = Util.k(size);
         int mid = start + k;
         if (m <= k) {
             List<byte[]> subtreeConsistencySet = subtreeSnapshotConsistency(start, mid, m);
@@ -61,7 +61,7 @@ public class MerkleTree {
         if (size <= 1) {
             return new ArrayList<>();
         }
-        int mid = start + k(size);
+        int mid = start + Util.k(size);
         if (leafIndex < mid) {
             List<byte[]> subtreePath = subtreePathAtSnapshot(leafIndex, start, mid);
             subtreePath.add(subtreeHash(mid, end, leafDAOFunction.apply(mid, end)));
@@ -79,39 +79,16 @@ public class MerkleTree {
         if (size == 0) {
             return emptyTree();
         } else if (size == 1) {
-            return singleLeafTree(iterator.next());
+            return Util.leafHash(iterator.next(), messageDigest);
         } else {
-            int mid = start + k(size);
+            int mid = start + Util.k(size);
             byte[] leftSubtreeHash = subtreeHash(start, mid, iterator);
             byte[] rightSubtreeHash = subtreeHash(mid, end, iterator);
-            return intermediateNode(leftSubtreeHash, rightSubtreeHash);
+            return Util.branchHash(leftSubtreeHash, rightSubtreeHash, messageDigest);
         }
     }
 
     private byte[] emptyTree() {
         return messageDigest.digest();
-    }
-
-    private byte[] singleLeafTree(byte[] input) {
-        messageDigest.update((byte) 0);
-        return messageDigest.digest(input);
-    }
-
-    private byte[] intermediateNode(byte[] left, byte[] right) {
-        messageDigest.update((byte) 1);
-        messageDigest.update(left);
-        return messageDigest.digest(right);
-    }
-
-    public static int k(int n) {
-        assert n > 1;
-
-        int split = 1;
-        do {
-            split <<= 1;
-        } while (split < n);
-
-        // Get the largest power of two smaller than i.
-        return split >> 1;
     }
 }

--- a/src/main/java/uk/gov/verifiablelog/merkletree/MerkleTree.java
+++ b/src/main/java/uk/gov/verifiablelog/merkletree/MerkleTree.java
@@ -103,7 +103,7 @@ public class MerkleTree {
         return messageDigest.digest(right);
     }
 
-    private int k(int n) {
+    public static int k(int n) {
         assert n > 1;
 
         int split = 1;

--- a/src/main/java/uk/gov/verifiablelog/merkletree/MerkleTree.java
+++ b/src/main/java/uk/gov/verifiablelog/merkletree/MerkleTree.java
@@ -2,6 +2,7 @@ package uk.gov.verifiablelog.merkletree;
 
 import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -12,14 +13,19 @@ public class MerkleTree {
 
     private Function<Integer, byte[]> leafDAOFunction;
     private Supplier<Integer> leafSizeDAOFunction;
+    private final Iterable<byte[]> entryIterable;
 
-    public MerkleTree(MessageDigest messageDigest, Function<Integer, byte[]> leafDAOFunction, Supplier<Integer> leafSizeDAOFunction) {
+    private Iterator<byte[]> currentIterator;
+
+    public MerkleTree(MessageDigest messageDigest, Function<Integer, byte[]> leafDAOFunction, Supplier<Integer> leafSizeDAOFunction, Iterable<byte[]> entryIterable) {
         this.messageDigest = messageDigest;
         this.leafDAOFunction = leafDAOFunction;
         this.leafSizeDAOFunction = leafSizeDAOFunction;
+        this.entryIterable = entryIterable;
     }
 
     public byte[] currentRoot() {
+        currentIterator = entryIterable.iterator();
         return subtreeHash(0, leafSizeDAOFunction.get());
     }
 
@@ -79,7 +85,7 @@ public class MerkleTree {
         if (size == 0) {
             return emptyTree();
         } else if (size == 1) {
-            return singleLeafTree(leafDAOFunction.apply(start));
+            return singleLeafTree(currentIterator.next());
         } else {
             int mid = start + k(size);
             byte[] leftSubtreeHash = subtreeHash(start, mid);

--- a/src/main/java/uk/gov/verifiablelog/merkletree/MerkleTreeVerification.java
+++ b/src/main/java/uk/gov/verifiablelog/merkletree/MerkleTreeVerification.java
@@ -1,0 +1,33 @@
+package uk.gov.verifiablelog.merkletree;
+
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static uk.gov.verifiablelog.merkletree.Util.branchHash;
+import static uk.gov.verifiablelog.merkletree.Util.k;
+
+public class MerkleTreeVerification {
+    static boolean isValidAuditProof(byte[] rootHash, int treeSize, int leafIndex, List<byte[]> auditPath, byte[] leafData) {
+        byte[] computedRootHash = rootHashFromAuditPath(treeSize, leafIndex, new ArrayList<>(auditPath), leafData, Util.sha256Instance());
+        return Arrays.equals(computedRootHash, rootHash);
+    }
+
+    private static byte[] rootHashFromAuditPath(int treeSize, int leafIndex, List<byte[]> auditPath, byte[] leafData, MessageDigest digest) {
+        if (treeSize == 1) {
+            assert auditPath.isEmpty();
+            return Util.leafHash(leafData, digest);
+        }
+        int k = k(treeSize);
+        byte[] nextHash = auditPath.remove(auditPath.size() - 1);
+        if (leafIndex < k) {
+            byte[] leftChild = rootHashFromAuditPath(k, leafIndex, auditPath, leafData, digest);
+            return branchHash(leftChild, nextHash, digest);
+        } else {
+            byte[] rightChild = rootHashFromAuditPath(treeSize - k, leafIndex - k, auditPath, leafData, digest);
+            return branchHash(nextHash, rightChild, digest);
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/verifiablelog/merkletree/Util.java
+++ b/src/main/java/uk/gov/verifiablelog/merkletree/Util.java
@@ -1,0 +1,37 @@
+package uk.gov.verifiablelog.merkletree;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class Util {
+    public static int k(int n) {
+        assert n > 1;
+
+        int split = 1;
+        do {
+            split <<= 1;
+        } while (split < n);
+
+        // Get the largest power of two smaller than i.
+        return split >> 1;
+    }
+
+    static byte[] branchHash(byte[] left, byte[] right, MessageDigest digest) {
+        digest.update(new byte[]{0x01});
+        digest.update(left);
+        return digest.digest(right);
+    }
+
+    static byte[] leafHash(byte[] leafData, MessageDigest digest) {
+        digest.update(new byte[]{0x00});
+        return digest.digest(leafData);
+    }
+
+    static MessageDigest sha256Instance() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("can't happen", e);
+        }
+    }
+}

--- a/src/test/java/uk/gov/verifiablelog/merkletree/MerkleTreeTests.java
+++ b/src/test/java/uk/gov/verifiablelog/merkletree/MerkleTreeTests.java
@@ -38,7 +38,7 @@ public class MerkleTreeTests {
     @Before
     public void setup() throws NoSuchAlgorithmException {
         leafValues = new ArrayList<>();
-        merkleTree = new MerkleTree(MessageDigest.getInstance("SHA-256"), i -> leafValues.get(i), () -> leafValues.size());
+        merkleTree = new MerkleTree(MessageDigest.getInstance("SHA-256"), i -> leafValues.get(i), () -> leafValues.size(), leafValues);
     }
 
     @Test
@@ -168,7 +168,7 @@ public class MerkleTreeTests {
 
     private MerkleTree sha256MerkleTree(Function<Integer, byte[]> leafAccessFunction, Supplier<Integer> leafSizeFunction) {
         try {
-            return new MerkleTree(MessageDigest.getInstance("SHA-256"), leafAccessFunction, leafSizeFunction);
+            return new MerkleTree(MessageDigest.getInstance("SHA-256"), leafAccessFunction, leafSizeFunction, null);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("can't happen"); // can't happen, SHA-256 is guaranteed
         }

--- a/src/test/java/uk/gov/verifiablelog/merkletree/MerkleTreeTests.java
+++ b/src/test/java/uk/gov/verifiablelog/merkletree/MerkleTreeTests.java
@@ -19,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.quicktheories.quicktheories.QuickTheory.qt;
 import static org.quicktheories.quicktheories.generators.SourceDSL.*;
+import static uk.gov.verifiablelog.merkletree.MerkleTree.k;
 
 public class MerkleTreeTests {
 
@@ -169,25 +170,38 @@ public class MerkleTreeTests {
 
     @Test
     public void property_canConstructRootHashFromLeafAndAuditPath() throws Exception {
-        qt().forAll(lists().allListsOf(strings().numeric()).ofSizeBetween(2,1000))
-                .check(entries -> {
+        qt().forAll(lists().allListsOf(strings().numeric()).ofSizeBetween(2,1000), integers().between(0,999))
+                .assuming((entries, leafIndex) -> leafIndex < entries.size())
+                .check((entries, leafIndex) -> {
                     MerkleTree merkleTree = sha256MerkleTree((i, j) -> entries.subList(i, j).stream().map(String::getBytes).iterator(), entries::size);
-                    int leafIndex = 0;
                     List<byte[]> auditPath = merkleTree.pathToRootAtSnapshot(leafIndex, entries.size());
                     return isValidAuditProof(merkleTree.currentRoot(), entries.size(), leafIndex, auditPath, entries.get(leafIndex).getBytes());
                 });
     }
 
-    private boolean isValidAuditProof(byte[] rootHash, int treeSize, int leafIndex, List<byte[]> auditPath, byte[] leafData) {
-        // TODO: use leafIndex to hash in correct order
-        byte[] hashAccumulator = leafHash(leafData);
-        for (byte[] uncle : auditPath) {
-            hashAccumulator = branchHash(hashAccumulator, uncle);
-        }
-        return Arrays.equals(hashAccumulator, rootHash);
+    private static boolean isValidAuditProof(byte[] rootHash, int treeSize, int leafIndex, List<byte[]> auditPath, byte[] leafData) {
+        byte[] computedRootHash = rootHashFromAuditPath(treeSize, leafIndex, new ArrayList<>(auditPath), leafData);
+        return Arrays.equals(computedRootHash, rootHash);
     }
 
-    private byte[] branchHash(byte[] left, byte[] right) {
+    private static byte[] rootHashFromAuditPath(int treeSize, int leafIndex, List<byte[]> auditPath, byte[] leafData) {
+        if (treeSize == 1) {
+            assert auditPath.isEmpty();
+            return leafHash(leafData);
+        }
+        int k = k(treeSize);
+        byte[] nextHash = auditPath.remove(auditPath.size() - 1);
+        if (leafIndex < k) {
+            byte[] leftChild = rootHashFromAuditPath(k, leafIndex, auditPath, leafData);
+            return branchHash(leftChild, nextHash);
+        }
+        else {
+            byte[] rightChild = rootHashFromAuditPath(treeSize - k, leafIndex - k, auditPath, leafData);
+            return branchHash(nextHash, rightChild);
+        }
+    }
+
+    private static byte[] branchHash(byte[] left, byte[] right) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             digest.update(new byte[] {0x01});
@@ -198,7 +212,7 @@ public class MerkleTreeTests {
         }
     }
 
-    private byte[] leafHash(byte[] leafData) {
+    private static byte[] leafHash(byte[] leafData) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             digest.update(new byte[] {0x00});


### PR DESCRIPTION
This creates code to verify an audit proof, and adds a property test to verify that a generated audit proof can be used to recalculate the given root hash.
