### PR TITLE
Add licence

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,7 @@
+(C) Crown Copyright 2016
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # verifiable-log
+
+## Licence
+
+© Crown Copyright, [MIT Licence](LICENSE.txt).


### PR DESCRIPTION
In order to make it clear what terms people can use this code under, we
should add a licence.  I've added an MIT licence notice.

(boring English usage note: British English prefers "licence" for the
noun rather than "license", so I've used this in the README.  However
I've used LICENSE.txt for the filename under principle of least surprise
for any automated systems that try to search for licence based on
filename.  I've also used "sublicense" in the licence text because it
was copy/pasted from the MIT licence text at the OSI website.)
